### PR TITLE
Fix boss portrait error

### DIFF
--- a/app/ui/views/item/main_menu.js
+++ b/app/ui/views/item/main_menu.js
@@ -102,7 +102,15 @@ var MainMenuItemView = Backbone.Marionette.ItemView.extend({
       var bossCard = SDK.CardFactory.cardForIdentifier(data.boss_battle.boss_id);
       if (bossCard != null) {
         data.boss_battle_name = bossCard.getName();
-        data.boss_battle_portrait = bossCard.getSpeechResource().img;
+        var speechResource = bossCard.getSpeechResource();
+        if (speechResource && speechResource.img) {
+          data.boss_battle_portrait = speechResource.img;
+        } else {
+          var portraitResource = bossCard.getPortraitResource();
+          if (portraitResource && portraitResource.img) {
+            data.boss_battle_portrait = portraitResource.img;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- avoid null dereference when boss portrait lacks speech asset

## Testing
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847145bcf988330ac9d919b9d6c4655