### PR TITLE
Switch infra defaults to x86_64

### DIFF
--- a/docs/infrastructure/COSTS.md
+++ b/docs/infrastructure/COSTS.md
@@ -59,11 +59,9 @@ scale to twice that amount at 8 vCPU and 4GB of memory.
 
 Based on these figures, an instance type with 2 vCPU and 1GB of memory would be
 suitable, as we can scale between 2-4 of these to handle our traffic. AWS
-offers `t3.micro` and `t4g.micro` instances in this configuration. The EC2 Free
+offers `t3.micro` instances in this configuration. The EC2 Free
 Tier includes one `t3.micro` for 12 months, with each additional costing around
-$8/mo. The `t4g.micro` instance uses ARM processors, and instead costs around
-$6/mo. When running 4 instances, these end up at approximately the same total
-cost. The `t` series instances are considered "burstable" instances, which can
+$8/mo. This instance type uses x86_64 processors. The `t` series instances are considered "burstable" instances, which can
 provide full compute power for a little over two hours before being throttled.
 With a low-traffic service, this is a non-issue, as running at less than full
 capacity will "reset" this timer.
@@ -78,8 +76,8 @@ works well with our API and Worker services, but 2 minutes is generally not
 long enough to allow in-progress games to finish. However, we can use Spot
 instances in staging, where losing games is not a big deal.
 
-In summary, running two `t4g.micro` Spot instances to power a staging ECS
-cluster would cost about $4 per month.
+In summary, running two `t3.micro` Spot instances to power a staging ECS
+cluster would cost about $5 per month.
 
 ### EBS Storage Pricing ($2/mo)
 
@@ -116,7 +114,7 @@ environment:
 
 Postgres:
 
-- AWS RDS provides one free `db.t4g.micro` instance per AWS account.
+- AWS RDS provides one free `db.t3.micro` instance per AWS account.
 - This instance type has 2 vCPU, 1GB of memory, and 20GB of storage.
 - 20GB of backups are also included for free.
 - After the Free Tier expires, this is around $12/mo
@@ -132,7 +130,7 @@ Redis:
 In order to avoid the $24/mo in billing after the Free Tier expires, we can run
 Redis and Postgres in ECS instead. This comes with its own costs, including:
 
-- One `t4g.micro` Spot instance to provide the compute ($1.83/mo)
+- One `t3.micro` Spot instance to provide the compute ($2.25/mo)
 - One DNS hosted zone for service discovery via AWS CloudMap ($0.50/mo)
 - One 8GB EBS disk for persisting Postgres data across containers ($0.64/mo)
 - 8GB EBS disk snapshots for backups ($0.40/mo each)

--- a/terraform/modules/alarms/rds/main.tf
+++ b/terraform/modules/alarms/rds/main.tf
@@ -1,6 +1,6 @@
 locals {
   memory_available = {
-    "db.t4g.micro" = 1.0 * 1000 * 1000 * 1000 # Bytes.
+    "db.t3.micro" = 1.0 * 1000 * 1000 * 1000 # Bytes.
   }
 }
 

--- a/terraform/modules/ecr_repository/variables.tf
+++ b/terraform/modules/ecr_repository/variables.tf
@@ -12,7 +12,7 @@ variable "about_text" {
 variable "architectures" {
   type        = list(string)
   description = "The CPU architectures of images in this ECR repository."
-  default     = ["ARM 64"]
+  default     = ["x86_64"]
 }
 
 variable "description" {

--- a/terraform/modules/ecs_cluster/capacity_spot.tf
+++ b/terraform/modules/ecs_cluster/capacity_spot.tf
@@ -3,8 +3,8 @@ locals {
   # Using on-demand price essentially guarantees Spot placement, and we still
   # get a 70% discount when placement succeeds.
   prices = {
-    "t4g.micro" = 0.0084 # 0.0025 after 70% discount. 
-    "t4g.small" = 0.0168 # 0.0050 after 70% discount. Gives 2x RAM.
+    "t3.micro" = 0.0104 # 0.0031 after 70% discount.
+    "t3.small" = 0.0208 # 0.0062 after 70% discount. Gives 2x RAM.
   }
 }
 

--- a/terraform/modules/ecs_cluster/variables.tf
+++ b/terraform/modules/ecs_cluster/variables.tf
@@ -15,7 +15,7 @@ variable "subnets" {
 variable "architecture" {
   type        = string
   description = "The machine architecture to use for ECS-EC2 instances (amd64 or arm64)."
-  default     = "arm64"
+  default     = "amd64"
 }
 
 variable "use_custom_ami" {
@@ -33,7 +33,7 @@ variable "custom_ami_id" {
 variable "instance_type" {
   type        = string
   description = "The instance type to use for ECS-EC2 instances."
-  default     = "t4g.micro"
+  default     = "t3.micro"
 }
 
 variable "root_volume_size" {

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -44,7 +44,7 @@ variable "container_cpu" {
 variable "container_mem" {
   type        = number
   description = "The amount of memory to allocate to each container."
-  default     = 350 # Allows for 2 containers on a t4g.micro instance.
+  default     = 350 # Allows for 2 containers on a t3.micro instance.
 }
 
 variable "command" {

--- a/terraform/modules/postgres_db/variables.tf
+++ b/terraform/modules/postgres_db/variables.tf
@@ -10,7 +10,7 @@ variable "postgres_version" {
 
 variable "instance_type" {
   type    = string
-  default = "db.t4g.micro"
+  default = "db.t3.micro"
 }
 
 variable "storage" {


### PR DESCRIPTION
## Summary
- default ECS cluster uses amd64 and t3.micro instances
- update Spot pricing table
- adjust docs to mention x86_64 and t3.micro
- update default RDS instance type and alarms
- document t3.micro usage

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6855409ac4c0833083d3109e4ec6970a